### PR TITLE
Feature/controller-enhancements

### DIFF
--- a/lib/src/widgets/mesh_gradient/mesh_gradient_controller.dart
+++ b/lib/src/widgets/mesh_gradient/mesh_gradient_controller.dart
@@ -277,17 +277,22 @@ class MeshGradientController {
     int repeatCount = 0,
     Duration pauseBetweenRepeats = Duration.zero,
   }) async {
-    int currentRepeat = 0;
+    int repeatsLeft = repeatCount;
+    bool repeatIndefinitely = repeatCount == 0;
 
-    while (repeatCount == 0 || currentRepeat < repeatCount) {
+    while (repeatIndefinitely || repeatsLeft > 0) {
+      if (_isDisposed) {
+        return;
+      }
+
       await animation();
 
       if (pauseBetweenRepeats > Duration.zero) {
         await Future.delayed(pauseBetweenRepeats);
       }
 
-      if (repeatCount > 0) {
-        currentRepeat++;
+      if (!repeatIndefinitely) {
+        repeatsLeft--;
       }
     }
   }

--- a/lib/src/widgets/mesh_gradient/mesh_gradient_controller.dart
+++ b/lib/src/widgets/mesh_gradient/mesh_gradient_controller.dart
@@ -22,6 +22,9 @@ class MeshGradientController {
   /// A list to keep track of all active animation controllers.
   final List<AnimationController> _activeAnimationControllers = [];
 
+  /// Tracks whether this controller has been disposed.
+  bool _isDisposed = false;
+
   /// Constructs a [MeshGradientController].
   ///
   /// Requires a list of [MeshGradientPoint]s to initialize the points and a [TickerProvider]
@@ -36,19 +39,19 @@ class MeshGradientController {
   /// This method stops all ongoing animations and disposes of all resources
   /// used by the controller.
   void dispose() {
-    if (points.value.isNotEmpty) {
-      stopAllAnimations();
-      points.dispose();
-      points.value.clear();
-      isAnimating.dispose();
-    }
+    if (_isDisposed) return;
+
+    stopAllAnimations();
+    points.dispose();
+    isAnimating.dispose();
+    _isDisposed = true;
   }
 
   /// Checks if the controller is disposed.
   ///
   /// Returns true if the controller has been disposed, false otherwise.
   bool isDisposed() {
-    return points.value.isEmpty;
+    return _isDisposed;
   }
 
   /// Stops all ongoing animations.
@@ -75,6 +78,10 @@ class MeshGradientController {
     Curve curve = Curves.ease,
     Duration duration = const Duration(milliseconds: 300),
   }) async {
+    if (_isDisposed) {
+      throw StateError('Cannot animate point on a disposed controller');
+    }
+
     try {
       final completer = Completer();
 
@@ -157,6 +164,10 @@ class MeshGradientController {
     int repeatCount = 1,
     Duration pauseBetweenRepeats = Duration.zero,
   }) async {
+    if (_isDisposed) {
+      throw StateError('Cannot animate sequence on a disposed controller');
+    }
+
     Future<void> singleSequenceAnimation() async {
       try {
         final completer = Completer();

--- a/lib/src/widgets/mesh_gradient/mesh_gradient_controller.dart
+++ b/lib/src/widgets/mesh_gradient/mesh_gradient_controller.dart
@@ -18,7 +18,7 @@ class MeshGradientController {
 
   /// The [TickerProvider] for the animation controller.
   final TickerProvider vsync;
-  
+
   /// A list to keep track of all active animation controllers.
   final List<AnimationController> _activeAnimationControllers = [];
 
@@ -36,9 +36,12 @@ class MeshGradientController {
   /// This method stops all ongoing animations and disposes of all resources
   /// used by the controller.
   void dispose() {
-    stopAllAnimations();
-    points.dispose();
-    isAnimating.dispose();
+    if (points.value.isNotEmpty) {
+      stopAllAnimations();
+      points.dispose();
+      points.value.clear();
+      isAnimating.dispose();
+    }
   }
 
   /// Checks if the controller is disposed.
@@ -264,14 +267,14 @@ class MeshGradientController {
     Duration pauseBetweenRepeats = Duration.zero,
   }) async {
     int currentRepeat = 0;
-    
+
     while (repeatCount == 0 || currentRepeat < repeatCount) {
       await animation();
-      
+
       if (pauseBetweenRepeats > Duration.zero) {
         await Future.delayed(pauseBetweenRepeats);
       }
-      
+
       if (repeatCount > 0) {
         currentRepeat++;
       }
@@ -291,7 +294,8 @@ class MeshGradientController {
     Duration pauseBetweenRepeats = Duration.zero,
   }) async {
     await repeatAnimation(
-      animation: () => animatePoint(pointIndex, newPoint, curve: curve, duration: duration),
+      animation: () =>
+          animatePoint(pointIndex, newPoint, curve: curve, duration: duration),
       repeatCount: repeatCount,
       pauseBetweenRepeats: pauseBetweenRepeats,
     );

--- a/lib/src/widgets/mesh_gradient/mesh_gradient_controller.dart
+++ b/lib/src/widgets/mesh_gradient/mesh_gradient_controller.dart
@@ -32,6 +32,11 @@ class MeshGradientController {
     points.dispose();
   }
 
+ /// check if the controller is disposed or not
+  bool  isDisposed (){
+    return points.value.isEmpty;
+  } 
+
   /// Animates a single point to a new state.
   ///
   /// The [pointIndex] specifies the index of the point to animate, and [newPoint] specifies

--- a/lib/src/widgets/mesh_gradient/mesh_gradient_controller.dart
+++ b/lib/src/widgets/mesh_gradient/mesh_gradient_controller.dart
@@ -7,7 +7,8 @@ import 'package:mesh_gradient/mesh_gradient.dart';
 ///
 /// This controller is responsible for managing the animation of points within a mesh gradient.
 /// It provides methods to animate individual points or a sequence of points with custom
-/// durations, curves, and other animation parameters.
+/// durations, curves, and other animation parameters. It also supports repeating animations
+/// and stopping all ongoing animations.
 class MeshGradientController {
   /// A [ValueNotifier] that notifies listeners of changes to the mesh gradient points.
   late ValueNotifier<List<MeshGradientPoint>> points;
@@ -17,6 +18,9 @@ class MeshGradientController {
 
   /// The [TickerProvider] for the animation controller.
   final TickerProvider vsync;
+  
+  /// A list to keep track of all active animation controllers.
+  final List<AnimationController> _activeAnimationControllers = [];
 
   /// Constructs a [MeshGradientController].
   ///
@@ -28,14 +32,34 @@ class MeshGradientController {
   }) : points = ValueNotifier(points);
 
   /// Disposes the controller and its resources.
+  ///
+  /// This method stops all ongoing animations and disposes of all resources
+  /// used by the controller.
   void dispose() {
+    stopAllAnimations();
     points.dispose();
+    isAnimating.dispose();
   }
 
- /// check if the controller is disposed or not
-  bool  isDisposed (){
+  /// Checks if the controller is disposed.
+  ///
+  /// Returns true if the controller has been disposed, false otherwise.
+  bool isDisposed() {
     return points.value.isEmpty;
-  } 
+  }
+
+  /// Stops all ongoing animations.
+  ///
+  /// This method stops and disposes of all active animation controllers,
+  /// effectively halting all ongoing animations.
+  void stopAllAnimations() {
+    for (var controller in _activeAnimationControllers) {
+      controller.stop();
+      controller.dispose();
+    }
+    _activeAnimationControllers.clear();
+    isAnimating.value = false;
+  }
 
   /// Animates a single point to a new state.
   ///
@@ -75,6 +99,8 @@ class MeshGradientController {
         vsync: vsync,
       );
 
+      _activeAnimationControllers.add(animationController);
+
       void listener() {
         final Offset animatedPosition = positionTween.evaluate(
           CurvedAnimation(parent: animationController, curve: curve),
@@ -103,6 +129,7 @@ class MeshGradientController {
             status == AnimationStatus.dismissed) {
           animationController.removeListener(listener);
           animationController.dispose();
+          _activeAnimationControllers.remove(animationController);
           completer.complete();
         }
       });
@@ -111,7 +138,7 @@ class MeshGradientController {
     } catch (e) {
       rethrow;
     } finally {
-      isAnimating.value = false;
+      isAnimating.value = _activeAnimationControllers.isNotEmpty;
     }
   }
 
@@ -119,100 +146,155 @@ class MeshGradientController {
   ///
   /// The method takes a [duration] for the entire sequence and a list of [sequences]
   /// specifying the animation details for each point in the sequence.
-  ///
+  /// [repeatCount] specifies the number of times to repeat the entire sequence. If set to 0, it repeats indefinitely.
+  /// [pauseBetweenRepeats] is an optional pause duration between repeats.
   Future<void> animateSequence({
-    /// The total duration of the animation sequence.
     required Duration duration,
-
-    /// A list of [AnimationSequence] objects, each defining an animation for a specific point.
     required List<AnimationSequence> sequences,
+    int repeatCount = 1,
+    Duration pauseBetweenRepeats = Duration.zero,
   }) async {
-    try {
-      final completer = Completer();
+    Future<void> singleSequenceAnimation() async {
+      try {
+        final completer = Completer();
 
-      AnimationController animationController = AnimationController(
-        duration: duration,
-        vsync: vsync,
-      );
-
-      isAnimating.value = true;
-
-      final indexSet = <int>{};
-      for (var sequence in sequences) {
-        if (!indexSet.add(sequence.pointIndex)) {
-          throw ArgumentError(
-              'Duplicate sequence index detected: ${sequence.pointIndex}. Each sequence must have a unique point index.');
-        }
-        final int pointIndex = sequence.pointIndex;
-        final MeshGradientPoint newPoint = sequence.newPoint;
-
-        if (pointIndex < 0 || pointIndex >= points.value.length) {
-          throw ArgumentError('Index out of bounds');
-        }
-
-        final MeshGradientPoint startPoint = points.value[pointIndex];
-        final Tween<Offset> positionTween = Tween(
-          begin: startPoint.position,
-          end: newPoint.position,
+        AnimationController animationController = AnimationController(
+          duration: duration,
+          vsync: vsync,
         );
 
-        final ColorTween colorTween = ColorTween(
-          begin: startPoint.color,
-          end: newPoint.color,
-        );
+        _activeAnimationControllers.add(animationController);
 
-        final Animation<double> sequenceAnimation = CurvedAnimation(
-          parent: animationController,
-          curve: sequence.interval,
-        );
+        isAnimating.value = true;
 
-        void sequenceListener() {
-          final Offset animatedPosition =
-              positionTween.evaluate(sequenceAnimation);
-          final Color? animatedColor = colorTween.evaluate(sequenceAnimation);
-          MeshGradientPoint animatedPoint = MeshGradientPoint(
-            position: animatedPosition,
-            color: animatedColor ?? Colors.transparent,
+        final indexSet = <int>{};
+        for (var sequence in sequences) {
+          if (!indexSet.add(sequence.pointIndex)) {
+            throw ArgumentError(
+                'Duplicate sequence index detected: ${sequence.pointIndex}. Each sequence must have a unique point index.');
+          }
+          final int pointIndex = sequence.pointIndex;
+          final MeshGradientPoint newPoint = sequence.newPoint;
+
+          if (pointIndex < 0 || pointIndex >= points.value.length) {
+            throw ArgumentError('Index out of bounds');
+          }
+
+          final MeshGradientPoint startPoint = points.value[pointIndex];
+          final Tween<Offset> positionTween = Tween(
+            begin: startPoint.position,
+            end: newPoint.position,
           );
 
-          List<MeshGradientPoint> updatedPoints = List.from(points.value);
-          updatedPoints[pointIndex] = animatedPoint;
+          final ColorTween colorTween = ColorTween(
+            begin: startPoint.color,
+            end: newPoint.color,
+          );
 
-          points.value = updatedPoints;
+          final Animation<double> sequenceAnimation = CurvedAnimation(
+            parent: animationController,
+            curve: sequence.interval,
+          );
+
+          void sequenceListener() {
+            final Offset animatedPosition =
+                positionTween.evaluate(sequenceAnimation);
+            final Color? animatedColor = colorTween.evaluate(sequenceAnimation);
+            MeshGradientPoint animatedPoint = MeshGradientPoint(
+              position: animatedPosition,
+              color: animatedColor ?? Colors.transparent,
+            );
+
+            List<MeshGradientPoint> updatedPoints = List.from(points.value);
+            updatedPoints[pointIndex] = animatedPoint;
+
+            points.value = updatedPoints;
+          }
+
+          sequenceAnimation.addListener(sequenceListener);
+
+          void sequenceStatusListener(AnimationStatus status) {
+            if (status == AnimationStatus.completed ||
+                status == AnimationStatus.dismissed) {
+              sequenceAnimation.removeListener(sequenceListener);
+              sequenceAnimation.removeStatusListener(sequenceStatusListener);
+            }
+          }
+
+          sequenceAnimation.addStatusListener(sequenceStatusListener);
         }
 
-        sequenceAnimation.addListener(sequenceListener);
+        animationController.forward();
 
-        void sequenceStatusListener(AnimationStatus status) {
+        void animationStatusListener(AnimationStatus status) {
           if (status == AnimationStatus.completed ||
               status == AnimationStatus.dismissed) {
-            sequenceAnimation.removeListener(sequenceListener);
-            sequenceAnimation.removeStatusListener(sequenceStatusListener);
+            animationController.removeStatusListener(animationStatusListener);
+            animationController.dispose();
+            _activeAnimationControllers.remove(animationController);
+            completer.complete();
           }
         }
 
-        sequenceAnimation.addStatusListener(sequenceStatusListener);
+        animationController.addStatusListener(animationStatusListener);
+
+        await completer.future;
+      } catch (e) {
+        rethrow;
+      } finally {
+        isAnimating.value = _activeAnimationControllers.isNotEmpty;
       }
-
-      animationController.forward();
-
-      void animationStatusListener(AnimationStatus status) {
-        if (status == AnimationStatus.completed ||
-            status == AnimationStatus.dismissed) {
-          animationController.removeStatusListener(animationStatusListener);
-          animationController.dispose();
-          completer.complete();
-        }
-      }
-
-      animationController.addStatusListener(animationStatusListener);
-
-      await completer.future;
-    } catch (e) {
-      rethrow;
-    } finally {
-      isAnimating.value = false;
     }
+
+    await repeatAnimation(
+      animation: singleSequenceAnimation,
+      repeatCount: repeatCount,
+      pauseBetweenRepeats: pauseBetweenRepeats,
+    );
+  }
+
+  /// Repeats an animation for a specified number of times or indefinitely.
+  ///
+  /// [animation] is a function that performs the animation.
+  /// [repeatCount] specifies the number of times to repeat the animation. If set to 0, it repeats indefinitely.
+  /// [pauseBetweenRepeats] is an optional pause duration between repeats.
+  Future<void> repeatAnimation({
+    required Future<void> Function() animation,
+    int repeatCount = 0,
+    Duration pauseBetweenRepeats = Duration.zero,
+  }) async {
+    int currentRepeat = 0;
+    
+    while (repeatCount == 0 || currentRepeat < repeatCount) {
+      await animation();
+      
+      if (pauseBetweenRepeats > Duration.zero) {
+        await Future.delayed(pauseBetweenRepeats);
+      }
+      
+      if (repeatCount > 0) {
+        currentRepeat++;
+      }
+    }
+  }
+
+  /// Repeats a single point animation.
+  ///
+  /// This method animates a single point repeatedly using the specified parameters.
+  /// It uses [repeatAnimation] internally to handle the repetition logic.
+  Future<void> repeatPointAnimation(
+    int pointIndex,
+    MeshGradientPoint newPoint, {
+    Curve curve = Curves.ease,
+    Duration duration = const Duration(milliseconds: 300),
+    int repeatCount = 0,
+    Duration pauseBetweenRepeats = Duration.zero,
+  }) async {
+    await repeatAnimation(
+      animation: () => animatePoint(pointIndex, newPoint, curve: curve, duration: duration),
+      repeatCount: repeatCount,
+      pauseBetweenRepeats: pauseBetweenRepeats,
+    );
   }
 }
 

--- a/test/mesh_gradient_controller_test.dart
+++ b/test/mesh_gradient_controller_test.dart
@@ -1,0 +1,556 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mesh_gradient/mesh_gradient.dart';
+
+void main() {
+  group('MeshGradientController', () {
+    late MeshGradientController controller;
+    late List<MeshGradientPoint> initialPoints;
+
+    setUp(() {
+      initialPoints = [
+        MeshGradientPoint(
+          position: const Offset(0.2, 0.6),
+          color: Colors.red,
+        ),
+        MeshGradientPoint(
+          position: const Offset(0.4, 0.5),
+          color: Colors.blue,
+        ),
+        MeshGradientPoint(
+          position: const Offset(0.7, 0.4),
+          color: Colors.green,
+        ),
+        MeshGradientPoint(
+          position: const Offset(0.4, 0.9),
+          color: Colors.yellow,
+        ),
+      ];
+    });
+
+    tearDown(() {
+      if (!controller.isDisposed()) {
+        controller.dispose();
+      }
+    });
+
+    testWidgets('initializes with correct points', (WidgetTester tester) async {
+      controller = MeshGradientController(
+        points: initialPoints,
+        vsync: tester,
+      );
+
+      expect(controller.points.value, equals(initialPoints));
+      expect(controller.isAnimating.value, isFalse);
+      expect(controller.isDisposed(), isFalse);
+    });
+
+    group('disposal', () {
+      testWidgets('isDisposed returns false initially',
+          (WidgetTester tester) async {
+        controller = MeshGradientController(
+          points: initialPoints,
+          vsync: tester,
+        );
+
+        expect(controller.isDisposed(), isFalse);
+      });
+
+      testWidgets('isDisposed returns true after disposal',
+          (WidgetTester tester) async {
+        controller = MeshGradientController(
+          points: initialPoints,
+          vsync: tester,
+        );
+
+        controller.dispose();
+
+        expect(controller.isDisposed(), isTrue);
+      });
+
+      testWidgets('dispose can be called multiple times safely',
+          (WidgetTester tester) async {
+        controller = MeshGradientController(
+          points: initialPoints,
+          vsync: tester,
+        );
+
+        controller.dispose();
+        controller.dispose();
+        controller.dispose();
+
+        expect(controller.isDisposed(), isTrue);
+      });
+
+      testWidgets('animatePoint throws StateError after disposal',
+          (WidgetTester tester) async {
+        controller = MeshGradientController(
+          points: initialPoints,
+          vsync: tester,
+        );
+
+        controller.dispose();
+
+        expect(
+          () => controller.animatePoint(
+            0,
+            MeshGradientPoint(
+              position: const Offset(0.5, 0.5),
+              color: Colors.purple,
+            ),
+          ),
+          throwsA(isA<StateError>()),
+        );
+      });
+
+      testWidgets('animateSequence throws StateError after disposal',
+          (WidgetTester tester) async {
+        controller = MeshGradientController(
+          points: initialPoints,
+          vsync: tester,
+        );
+
+        controller.dispose();
+
+        expect(
+          () => controller.animateSequence(
+            duration: const Duration(milliseconds: 100),
+            sequences: [
+              AnimationSequence(
+                pointIndex: 0,
+                newPoint: MeshGradientPoint(
+                  position: const Offset(0.5, 0.5),
+                  color: Colors.purple,
+                ),
+                interval: const Interval(0.0, 1.0),
+              ),
+            ],
+          ),
+          throwsA(isA<StateError>()),
+        );
+      });
+
+      testWidgets('dispose stops all active animations',
+          (WidgetTester tester) async {
+        controller = MeshGradientController(
+          points: initialPoints,
+          vsync: tester,
+        );
+
+        // start animation
+        controller.animatePoint(
+          0,
+          MeshGradientPoint(
+            position: const Offset(0.8, 0.8),
+            color: Colors.purple,
+          ),
+          duration: const Duration(milliseconds: 500),
+        );
+
+        await tester.pump(const Duration(milliseconds: 50));
+        expect(controller.isAnimating.value, isTrue);
+
+        controller.dispose();
+
+        expect(controller.isAnimating.value, isFalse);
+        expect(controller.isDisposed(), isTrue);
+      });
+    });
+
+    group('animatePoint', () {
+      testWidgets('animates single point position and color',
+          (WidgetTester tester) async {
+        controller = MeshGradientController(
+          points: initialPoints,
+          vsync: tester,
+        );
+
+        final targetPoint = MeshGradientPoint(
+          position: const Offset(0.8, 0.8),
+          color: Colors.purple,
+        );
+
+        controller.animatePoint(
+          0,
+          targetPoint,
+          duration: const Duration(milliseconds: 100),
+        );
+
+        await tester.pump();
+        expect(controller.isAnimating.value, isTrue);
+
+        await tester.pump(const Duration(milliseconds: 50));
+        // point should be somewhere between start and end
+        final midPoint = controller.points.value[0];
+        expect(
+            midPoint.position.dx, isNot(equals(initialPoints[0].position.dx)));
+        expect(midPoint.position.dx, isNot(equals(targetPoint.position.dx)));
+
+        await tester.pumpAndSettle();
+        expect(controller.isAnimating.value, isFalse);
+        expect(
+            controller.points.value[0].position, equals(targetPoint.position));
+        expect(controller.points.value[0].color, equals(targetPoint.color));
+      });
+
+      testWidgets('throws ArgumentError for invalid index',
+          (WidgetTester tester) async {
+        controller = MeshGradientController(
+          points: initialPoints,
+          vsync: tester,
+        );
+
+        expect(
+          () => controller.animatePoint(
+            10,
+            MeshGradientPoint(
+              position: const Offset(0.5, 0.5),
+              color: Colors.purple,
+            ),
+          ),
+          throwsA(isA<ArgumentError>()),
+        );
+      });
+
+      testWidgets('completes animation future', (WidgetTester tester) async {
+        controller = MeshGradientController(
+          points: initialPoints,
+          vsync: tester,
+        );
+
+        var completed = false;
+
+        controller
+            .animatePoint(
+          0,
+          MeshGradientPoint(
+            position: const Offset(0.8, 0.8),
+            color: Colors.purple,
+          ),
+          duration: const Duration(milliseconds: 100),
+        )
+            .then((_) {
+          completed = true;
+        });
+
+        expect(completed, isFalse);
+        await tester.pumpAndSettle();
+        expect(completed, isTrue);
+      });
+    });
+
+    group('stopAllAnimations', () {
+      testWidgets('stops all active animations', (WidgetTester tester) async {
+        controller = MeshGradientController(
+          points: initialPoints,
+          vsync: tester,
+        );
+
+        // start multiple animations
+        controller.animatePoint(
+          0,
+          MeshGradientPoint(
+            position: const Offset(0.8, 0.8),
+            color: Colors.purple,
+          ),
+          duration: const Duration(milliseconds: 500),
+        );
+
+        controller.animatePoint(
+          1,
+          MeshGradientPoint(
+            position: const Offset(0.9, 0.9),
+            color: Colors.orange,
+          ),
+          duration: const Duration(milliseconds: 500),
+        );
+
+        await tester.pump(const Duration(milliseconds: 50));
+        expect(controller.isAnimating.value, isTrue);
+
+        controller.stopAllAnimations();
+
+        expect(controller.isAnimating.value, isFalse);
+      });
+
+      testWidgets('can be called when no animations are active',
+          (WidgetTester tester) async {
+        controller = MeshGradientController(
+          points: initialPoints,
+          vsync: tester,
+        );
+
+        expect(() => controller.stopAllAnimations(), returnsNormally);
+        expect(controller.isAnimating.value, isFalse);
+      });
+    });
+
+    group('animateSequence', () {
+      testWidgets('animates multiple points in sequence',
+          (WidgetTester tester) async {
+        controller = MeshGradientController(
+          points: initialPoints,
+          vsync: tester,
+        );
+
+        controller.animateSequence(
+          duration: const Duration(milliseconds: 200),
+          sequences: [
+            AnimationSequence(
+              pointIndex: 0,
+              newPoint: MeshGradientPoint(
+                position: const Offset(0.8, 0.8),
+                color: Colors.purple,
+              ),
+              interval: const Interval(0.0, 0.5, curve: Curves.easeIn),
+            ),
+            AnimationSequence(
+              pointIndex: 1,
+              newPoint: MeshGradientPoint(
+                position: const Offset(0.9, 0.9),
+                color: Colors.orange,
+              ),
+              interval: const Interval(0.5, 1.0, curve: Curves.easeOut),
+            ),
+          ],
+        );
+
+        await tester.pump();
+        expect(controller.isAnimating.value, isTrue);
+
+        await tester.pumpAndSettle();
+        expect(controller.isAnimating.value, isFalse);
+        expect(controller.points.value[0].position, const Offset(0.8, 0.8));
+        expect(controller.points.value[1].position, const Offset(0.9, 0.9));
+      });
+
+      testWidgets('throws ArgumentError for duplicate sequence indices',
+          (WidgetTester tester) async {
+        controller = MeshGradientController(
+          points: initialPoints,
+          vsync: tester,
+        );
+
+        expect(
+          () => controller.animateSequence(
+            duration: const Duration(milliseconds: 100),
+            sequences: [
+              AnimationSequence(
+                pointIndex: 0,
+                newPoint: MeshGradientPoint(
+                  position: const Offset(0.8, 0.8),
+                  color: Colors.purple,
+                ),
+                interval: const Interval(0.0, 0.5),
+              ),
+              AnimationSequence(
+                pointIndex: 0,
+                newPoint: MeshGradientPoint(
+                  position: const Offset(0.9, 0.9),
+                  color: Colors.orange,
+                ),
+                interval: const Interval(0.5, 1.0),
+              ),
+            ],
+          ),
+          throwsA(isA<ArgumentError>()),
+        );
+      });
+
+      testWidgets('repeats sequence specified number of times',
+          (WidgetTester tester) async {
+        controller = MeshGradientController(
+          points: initialPoints,
+          vsync: tester,
+        );
+
+        var animationCount = 0;
+
+        controller
+            .animateSequence(
+          duration: const Duration(milliseconds: 50),
+          sequences: [
+            AnimationSequence(
+              pointIndex: 0,
+              newPoint: MeshGradientPoint(
+                position: const Offset(0.8, 0.8),
+                color: Colors.purple,
+              ),
+              interval: const Interval(0.0, 1.0),
+            ),
+          ],
+          repeatCount: 3,
+        )
+            .then((_) {
+          animationCount++;
+        });
+
+        await tester.pump();
+        expect(controller.isAnimating.value, isTrue);
+
+        await tester.pumpAndSettle();
+        expect(controller.isAnimating.value, isFalse);
+        expect(animationCount, 1);
+      });
+    });
+
+    group('repeatAnimation', () {
+      testWidgets('repeats animation specified number of times',
+          (WidgetTester tester) async {
+        controller = MeshGradientController(
+          points: initialPoints,
+          vsync: tester,
+        );
+
+        var executionCount = 0;
+
+        Future<void> testAnimation() async {
+          executionCount++;
+          await Future.delayed(const Duration(milliseconds: 10));
+        }
+
+        controller.repeatAnimation(
+          animation: testAnimation,
+          repeatCount: 3,
+        );
+
+        await tester.pumpAndSettle();
+        expect(executionCount, 3);
+      });
+    });
+
+    group('repeatPointAnimation', () {
+      testWidgets('repeats point animation specified number of times',
+          (WidgetTester tester) async {
+        controller = MeshGradientController(
+          points: initialPoints,
+          vsync: tester,
+        );
+
+        controller.repeatPointAnimation(
+          0,
+          MeshGradientPoint(
+            position: const Offset(0.8, 0.8),
+            color: Colors.purple,
+          ),
+          duration: const Duration(milliseconds: 50),
+          repeatCount: 3,
+        );
+
+        await tester.pump();
+        expect(controller.isAnimating.value, isTrue);
+
+        await tester.pumpAndSettle();
+        expect(controller.isAnimating.value, isFalse);
+        expect(controller.points.value[0].position, const Offset(0.8, 0.8));
+      });
+    });
+
+    group('isAnimating', () {
+      testWidgets('is false initially', (WidgetTester tester) async {
+        controller = MeshGradientController(
+          points: initialPoints,
+          vsync: tester,
+        );
+
+        expect(controller.isAnimating.value, isFalse);
+      });
+
+      testWidgets('is true during animation', (WidgetTester tester) async {
+        controller = MeshGradientController(
+          points: initialPoints,
+          vsync: tester,
+        );
+
+        controller.animatePoint(
+          0,
+          MeshGradientPoint(
+            position: const Offset(0.8, 0.8),
+            color: Colors.purple,
+          ),
+          duration: const Duration(milliseconds: 100),
+        );
+
+        await tester.pump();
+        expect(controller.isAnimating.value, isTrue);
+
+        // cleanup: let animation complete
+        await tester.pumpAndSettle();
+      });
+
+      testWidgets('is false after animation completes',
+          (WidgetTester tester) async {
+        controller = MeshGradientController(
+          points: initialPoints,
+          vsync: tester,
+        );
+
+        controller.animatePoint(
+          0,
+          MeshGradientPoint(
+            position: const Offset(0.8, 0.8),
+            color: Colors.purple,
+          ),
+          duration: const Duration(milliseconds: 100),
+        );
+
+        await tester.pumpAndSettle();
+        expect(controller.isAnimating.value, isFalse);
+      });
+
+      testWidgets('tracks multiple concurrent animations',
+          (WidgetTester tester) async {
+        controller = MeshGradientController(
+          points: initialPoints,
+          vsync: tester,
+        );
+
+        controller.animatePoint(
+          0,
+          MeshGradientPoint(
+            position: const Offset(0.8, 0.8),
+            color: Colors.purple,
+          ),
+          duration: const Duration(milliseconds: 200),
+        );
+
+        controller.animatePoint(
+          1,
+          MeshGradientPoint(
+            position: const Offset(0.9, 0.9),
+            color: Colors.orange,
+          ),
+          duration: const Duration(milliseconds: 200),
+        );
+
+        await tester.pump();
+        expect(controller.isAnimating.value, isTrue);
+
+        await tester.pump(const Duration(milliseconds: 100));
+        expect(controller.isAnimating.value, isTrue);
+
+        await tester.pumpAndSettle();
+        expect(controller.isAnimating.value, isFalse);
+      });
+    });
+
+    group('AnimationSequence', () {
+      test('creates with correct values', () {
+        final sequence = AnimationSequence(
+          pointIndex: 0,
+          newPoint: MeshGradientPoint(
+            position: const Offset(0.5, 0.5),
+            color: Colors.red,
+          ),
+          interval: const Interval(0.0, 1.0),
+        );
+
+        expect(sequence.pointIndex, 0);
+        expect(sequence.newPoint.position, const Offset(0.5, 0.5));
+        expect(sequence.newPoint.color, Colors.red);
+        expect(sequence.interval.begin, 0.0);
+        expect(sequence.interval.end, 1.0);
+      });
+    });
+  });
+}


### PR DESCRIPTION
> [!NOTE]
> Implemented by @msamoeed in #25  

# Enhanced MeshGradientController with Integrated Sequence Repetition

## Changes
- Modified `animateSequence` method to include `repeatCount` and `pauseBetweenRepeats` parameters
- Integrated sequence repetition functionality directly into `animateSequence`
- Removed separate `repeatSequenceAnimation` method
- Refactored `animateSequence` for better code organization and reusability

## Motivation
This update streamlines the API for animating mesh gradient sequences by incorporating repetition functionality directly into the `animateSequence` method. It simplifies usage and reduces code duplication while maintaining flexibility for complex animations.

## Impact
- Improved API consistency and ease of use
- Enhanced control over sequence animations with built-in repetition
- Reduced method count in the controller class

## Usage Example
```dart
controller.animateSequence(
  duration: Duration(seconds: 2),
  sequences: [/* ... */],
  repeatCount: 3,
  pauseBetweenRepeats: Duration(milliseconds: 500),
);
```

This PR enhances the MeshGradientController's capabilities while simplifying its interface, making it more intuitive for developers to create complex, repeating gradient animations.